### PR TITLE
hide datepicker when you tab to another field

### DIFF
--- a/datepicker.js
+++ b/datepicker.js
@@ -118,6 +118,7 @@
     classChangeObserver(calendar, instance);
     window.addEventListener('click', oneHandler.bind(instance));
     window.addEventListener('focusin', oneHandler.bind(instance));
+    window.addEventListener('keyup', oneHandler.bind(instance));
 
     const parent = el.parentElement;
 
@@ -426,6 +427,7 @@
   function remove() {
     window.removeEventListener('click', oneHandler);
     window.removeEventListener('focusin', oneHandler);
+    window.removeEventListener('keyup', oneHandler);
     this.calendar.remove();
     this.observer.disconnect(); // Stop the mutationObserver. https://goo.gl/PgFCEr
 
@@ -485,6 +487,9 @@
 
     const calClasses = this.calendar.classList;
     const hidden = calClasses.contains('hidden');
+
+    // Only pay attention to `keyup` events if the character is the TAB key.
+    if (e.type === 'keyup' && e.keyCode !== 9) return;
 
     // Only pay attention to `focusin` events if the calendar's el is an <input>.
     // `focusin` bubbles, `focus` does not.


### PR DESCRIPTION
To reproduce this problem:

1. Create a form like so:
```yml
form
    - input[text]
    - input[text]
    - input[datepicker]
    - input[datepicker]
    - input[text]
    - input[text]
```
2. Now init the datepicker on the two datepicker fields
3. Finally, load the form in the browser, select the first input[text] field so it it active, and press the TAB key to cycle to the last input.

