### PR TITLE
Fixed timezone-related issue in highlighting of today's date on calendar

### DIFF
--- a/datepicker.js
+++ b/datepicker.js
@@ -379,7 +379,7 @@
 
     // Same year, same month?
     const today = new Date();
-    const isThisMonth = today.toJSON().slice(0, 7) === date.toJSON().slice(0, 7);
+    const isThisMonth = currentYear === today.getFullYear() && currentMonth === today.getMonth();
 
     // Calculations for the squares on the calendar.
     const copy = new Date(new Date(date).setDate(1));


### PR DESCRIPTION
By directly comparing the year and month of today's date to that of the currently shown month, the timezone issues of `toJSON` are avoided.