### PR TITLE
Improve usability of date range picker pair

### DIFF
--- a/src/datepicker.js
+++ b/src/datepicker.js
@@ -810,7 +810,6 @@ function adjustDateranges({ instance, deselect }) {
       first.minDate = first.originalMinDate
       second.minDate = second.originalMinDate
     } else {
-      first.minDate = first.dateSelected
       second.minDate = first.dateSelected
     }
   } else {
@@ -818,7 +817,6 @@ function adjustDateranges({ instance, deselect }) {
       second.maxDate = second.originalMaxDate
       first.maxDate = first.originalMaxDate
     } else {
-      second.maxDate = second.dateSelected
       first.maxDate = second.dateSelected
     }
   }


### PR DESCRIPTION
Only limit second picker min value by first picker value and first picker max value by second picker value.

This way the user cannot select invalid values, but is not forced to deselect the currently selected date on either picker to be able to change the value to:

1. Earlier date on the first picker
2. Later date on the second picker

as these values are only limited by the currently selected value on them selves.