### PR TITLE
Replace Sass Division with Multiplication to Resolve Dart Sass Deprecation Warnings

### DIFF
--- a/src/datepicker.scss
+++ b/src/datepicker.scss
@@ -116,7 +116,7 @@ $lightblue: lightblue;
     width: calc(100% / 3);
     cursor: pointer;
     opacity: .5;
-    transition: opacity $transition / 2;
+    transition: opacity $transition * .5;
 
     &.active, &:hover {
       opacity: 1;
@@ -141,8 +141,8 @@ $lightblue: lightblue;
 }
 
 .qs-arrow {
-  height: $width / 10;
-  width: $width / 10;
+  height: $width * .1;
+  width: $width * .1;
   position: relative;
   cursor: pointer;
   border-radius: $radius;
@@ -162,7 +162,7 @@ $lightblue: lightblue;
 
   &:after {
     content: '';
-    border: ($width / 40) solid transparent;
+    border: ($width * .025) solid transparent;
     position: absolute;
     top: 50%;
     transition: border .2s;
@@ -219,7 +219,7 @@ $lightblue: lightblue;
 
 .qs-square {
   width: calc(100% / 7);
-  height: $width / 10;
+  height: $width * .1;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
When I use Webpack to import the Sass from this project in my app I get deprecation warnings like:

```
DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($transition, 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

    ╷
119 │     transition: opacity $transition / 2;
    │                         ^^^^^^^^^^^^^^^
    ╵
    node_modules/js-datepicker/src/datepicker.scss 119:25  @import
```

This pull request will replace the use of division with multiplication.  The updates here are similar to [this pull request in the Bootstrap repo](https://github.com/twbs/bootstrap/pull/34571/files).

The compiled results should be identical to what they were before.  But I didn't know exactly which compression rules you were using to generate `datepicker.min.css`, so you may want to test to make sure the results really are the same.