### PR TITLE
remove scss div deprecation warnings

### DIFF
--- a/src/datepicker.scss
+++ b/src/datepicker.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 $width: 15.625em;
 $radius: $width * .016891;
 $transition: .3s;
@@ -116,7 +118,7 @@ $lightblue: lightblue;
     width: calc(100% / 3);
     cursor: pointer;
     opacity: .5;
-    transition: opacity $transition / 2;
+    transition: opacity math.div($transition, 2);
 
     &.active, &:hover {
       opacity: 1;
@@ -141,8 +143,8 @@ $lightblue: lightblue;
 }
 
 .qs-arrow {
-  height: $width / 10;
-  width: $width / 10;
+  height: math.div($width, 10);
+  width: math.div($width, 10);
   position: relative;
   cursor: pointer;
   border-radius: $radius;
@@ -162,7 +164,7 @@ $lightblue: lightblue;
 
   &:after {
     content: '';
-    border: ($width / 40) solid transparent;
+    border: math.div($width, 40) solid transparent;
     position: absolute;
     top: 50%;
     transition: border .2s;
@@ -219,7 +221,7 @@ $lightblue: lightblue;
 
 .qs-square {
   width: calc(100% / 7);
-  height: $width / 10;
+  height: math.div($width, 10);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/datepicker.scss
+++ b/src/datepicker.scss
@@ -115,7 +115,7 @@ $lightblue: lightblue;
     display: flex;
     justify-content: center;
     align-items: center;
-    width: calc(100% / 3);
+    width: #{'calc(100% / 3)'};
     cursor: pointer;
     opacity: .5;
     transition: opacity math.div($transition, 2);
@@ -220,7 +220,7 @@ $lightblue: lightblue;
 }
 
 .qs-square {
-  width: calc(100% / 7);
+  width: #{'calc(100% / 7)'};
   height: math.div($width, 10);
   display: flex;
   align-items: center;


### PR DESCRIPTION
Hi, i took another shot at solving the Sass warnings. I ran the build and and had also the precalculation of the calc() expressions. That should be fixed now with escaping the values. 

But there is still a difference in the build css - a new space character is now new but i couldn't see why it now exists but not before.