### PR TITLE
No hover interaction if disableYearOverlay

### DIFF
--- a/cypress/integration/options.js
+++ b/cypress/integration/options.js
@@ -680,6 +680,7 @@ describe('User options', function() {
 
         cy.get(singleDatepickerInput).click()
         cy.get(single.overlay).should('have.class', 'qs-hidden')
+        cy.get(`${single.controls} .qs-month-year`).should('have.class', 'qs-disabled-year-overlay')
         cy.get(`${single.controls} .qs-month-year`).click()
         cy.get(single.overlay).should('have.class', 'qs-hidden')
       })

--- a/src/datepicker.js
+++ b/src/datepicker.js
@@ -742,7 +742,7 @@ function createControls(date, instance, overlayOpen) {
   return [
     '<div class="qs-controls' + (overlayOpen ? ' qs-blur' : '') + '">',
     '<div class="qs-arrow qs-left"></div>',
-    '<div class="qs-month-year">',
+    '<div class="qs-month-year' + (instance.disableYearOverlay ? ' qs-disabled-year-overlay' : '') + '">',
     '<span class="qs-month">' + instance.months[date.getMonth()] + '</span>',
     '<span class="qs-year">' + date.getFullYear() + '</span>',
     '</div>',

--- a/src/datepicker.scss
+++ b/src/datepicker.scss
@@ -187,10 +187,13 @@ $lightblue: lightblue;
   font-weight: bold;
   transition: border .2s;
   border-bottom: 1px solid transparent;
-  cursor: pointer;
 
-  &:hover {
-    border-bottom: 1px solid gray;
+  &:not(.qs-disabled-year-overlay) {
+    cursor: pointer;
+    
+    &:hover {
+      border-bottom: 1px solid gray;
+    }
   }
 
   &:focus,


### PR DESCRIPTION
While using the datepicker I realised that, when I set the `disableYearOverlay` option to true, the **hover** interaction still exists (the cursor is a pointer and the font gets bold when hovering), which it is confusing in terms of UI, because if you click nothing will happen.